### PR TITLE
Implement parallax splash page

### DIFF
--- a/agentic/agents/ux.context.md
+++ b/agentic/agents/ux.context.md
@@ -24,3 +24,4 @@ Acts as the senior front‑end and user experience engineer. Obsesses over custo
 - Keep usage examples concise and actionable
 - Ensure output is easy to parse when automation flags are added
 - Reference agentic/projects/austin-events/designs/ux-style-guideline.context.md for styling the website and providing design library recommendatiotns
+- The splash page should showcase local art with a subtle parallax effect

--- a/agentic/projects/austin-events/plan.p2.md
+++ b/agentic/projects/austin-events/plan.p2.md
@@ -22,3 +22,8 @@
 ### 📘 austin-events.p2 - Story 3.1 – Quality Assurance
 - [x] Task 3.1.a – Add test for new API route
 - [ ] Task 3.1.b – Update CI instructions for Next.js build
+
+## 🧱 austin-events.p2 - Step 4 – Splash Page POC
+### 📘 austin-events.p2 - Story 4.1 – Parallax Hero
+- [x] Task 4.1.a – Add hero art with simple parallax effect
+- [x] Task 4.1.b – Style splash page per local vibe

--- a/pages/index.js
+++ b/pages/index.js
@@ -33,23 +33,27 @@ export default function Home() {
   const roles = Array.from(new Set(events.map(e => e.role)));
 
   return (
-    <main className="p-8">
-      <h1 className="text-4xl font-display mb-4 text-sunset">Austin Events</h1>
-      <div className="mb-4">
-        <Filter label="Category" value={category} options={categories} onChange={setCategory} />
-        <Filter label="Role" value={role} options={roles} onChange={setRole} />
-      </div>
-      <ul className="mb-6">
-        {filtered.map(e => (
-          <li key={e.id} className="mb-2">{e.title} - {e.category}</li>
-        ))}
-      </ul>
-      <h2 className="text-2xl font-display text-hotpink mb-2">Recommended</h2>
-      <ul>
-        {recommended.map(e => (
-          <li key={e.id}>{e.title}</li>
-        ))}
-      </ul>
-    </main>
+    <>
+      <section className="h-screen bg-[url('/austin-skyline.svg')] bg-cover bg-center bg-fixed flex items-center justify-center">
+        <h1 className="text-5xl font-display text-limestone drop-shadow-lg">Austin Events</h1>
+      </section>
+      <main className="p-8 bg-limestone text-earth">
+        <div className="mb-4">
+          <Filter label="Category" value={category} options={categories} onChange={setCategory} />
+          <Filter label="Role" value={role} options={roles} onChange={setRole} />
+        </div>
+        <ul className="mb-6">
+          {filtered.map(e => (
+            <li key={e.id} className="mb-2">{e.title} - {e.category}</li>
+          ))}
+        </ul>
+        <h2 className="text-2xl font-display text-hotpink mb-2">Recommended</h2>
+        <ul>
+          {recommended.map(e => (
+            <li key={e.id}>{e.title}</li>
+          ))}
+        </ul>
+      </main>
+    </>
   );
 }

--- a/public/austin-skyline.svg
+++ b/public/austin-skyline.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 300">
+  <defs>
+    <linearGradient id="grad" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ff6b35" />
+      <stop offset="100%" stop-color="#09c1b3" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="300" fill="url(#grad)" />
+  <path d="M0 250 L50 220 L100 240 L150 200 L200 230 L250 180 L300 210 L350 170 L400 215 L450 160 L500 205 L550 150 L600 180 L600 300 L0 300 Z" fill="#f2f0e8" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-size="48" fill="#ff3971" font-family="Bungee, sans-serif">Austin Vibes</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,9 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 @layer base {
+  html, body, #__next {
+    height: 100%;
+  }
   body {
     font-family: 'Open Sans', sans-serif;
     background-color: #f2f0e8;
     color: #a78b71;
+    scroll-behavior: smooth;
   }
 }


### PR DESCRIPTION
## Summary
- add parallax hero splash with local art
- allow smooth scrolling and full height layout
- note splash page requirement in UX context
- record splash page tasks in phase 2 plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c8639aec8321b50e1e097a7baa22