### PR TITLE
Implement mobile-first layout and Ticketmaster fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple demo web app listing events in Austin.
 
+The UI is built mobile first with responsive Tailwind classes so it looks great on small screens.
+
 ## Setup
 
 ```bash
@@ -24,3 +26,4 @@ npm test
 3. Each push to `main` automatically builds and deploys the site.
 4. Copy `.env.example` to `.env.local` and fill in your `TICKETMASTER_API_KEY` for local development.
 5. Add the same variable in the Vercel dashboard so the API route can access it during builds.
+6. When the key is provided, the `/api/events` endpoint pulls real Austin events from the Ticketmaster Discovery API.

--- a/agentic/projects/austin-events/plan.p2.md
+++ b/agentic/projects/austin-events/plan.p2.md
@@ -35,5 +35,12 @@
 - [x] Task 5.1.c – Provide `.env.example` and read API key from environment
 
 ### 📘 austin-events.p2 - Story 5.2 – Human Setup
-- [ ] Task 5.2.a – Create Vercel account and link GitHub repo
-- [ ] Task 5.2.b – Configure environment variables in Vercel dashboard
+- [x] Task 5.2.a – Create Vercel account and link GitHub repo
+- [x] Task 5.2.b – Configure environment variables in Vercel dashboard
+
+## 🧱 austin-events.p2 - Step 6 – Mobile & API Enhancements
+### 📘 austin-events.p2 - Story 6.1 – Mobile-First Layout
+- [x] Task 6.1.a – Optimize hero sections for small screens
+- [x] Task 6.1.b – Convert event list to responsive grid
+### 📘 austin-events.p2 - Story 6.2 – Ticketmaster API
+- [x] Task 6.2.a – Fetch real events when API key set

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -4,6 +4,7 @@ export default function Document() {
   return (
     <Html>
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <link href="https://fonts.googleapis.com/css2?family=Bungee&family=Bungee+Shade&family=Open+Sans:wght@400;700&display=swap" rel="stylesheet" />

--- a/pages/events.js
+++ b/pages/events.js
@@ -35,18 +35,18 @@ export default function Events() {
 
   return (
     <>
-      <section className="h-screen bg-[url('/austin-skyline.svg')] bg-cover bg-center bg-fixed flex items-center justify-center">
-        <h1 className="text-5xl font-display text-limestone drop-shadow-lg">Austin Events</h1>
+      <section className="min-h-screen bg-[url('/austin-skyline.svg')] bg-cover bg-center flex items-center justify-center p-8">
+        <h1 className="text-3xl sm:text-5xl font-display text-limestone drop-shadow-lg">Austin Events</h1>
       </section>
-      <main className="p-8 bg-limestone text-earth">
+      <main className="p-8 bg-limestone text-earth max-w-4xl mx-auto">
         <Link href="/" className="text-hotpink underline mb-4 inline-block">Back Home</Link>
         <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-center gap-2">
           <Filter label="Category" value={category} options={categories} onChange={setCategory} />
           <Filter label="Role" value={role} options={roles} onChange={setRole} />
         </div>
-        <ul className="mb-6">
+        <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
           {filtered.map(e => (
-            <li key={e.id} className="mb-2">{e.title} - {e.category}</li>
+            <li key={e.id} className="p-4 bg-white rounded shadow">{e.title} - {e.category}</li>
           ))}
         </ul>
         <h2 className="text-2xl font-display text-hotpink mb-2">Recommended</h2>

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,11 +3,11 @@ import Link from 'next/link';
 export default function Home() {
   return (
     <>
-      <section className="h-screen bg-[url('/austin-skyline.svg')] bg-cover bg-center bg-fixed flex flex-col items-center justify-center text-center">
-        <h1 className="text-6xl font-display text-limestone drop-shadow-lg mb-6">Austin Vibes</h1>
+      <section className="min-h-screen bg-[url('/austin-skyline.svg')] bg-cover bg-center flex flex-col items-center justify-center text-center p-8">
+        <h1 className="text-4xl sm:text-6xl font-display text-limestone drop-shadow-lg mb-6">Austin Vibes</h1>
         <Link href="/events" className="bg-hotpink text-limestone px-6 py-3 rounded shadow-md hover:bg-turquoise transition-colors">Browse Events</Link>
       </section>
-      <section className="p-8 bg-limestone text-earth flex flex-col items-start gap-4">
+      <section className="p-8 bg-limestone text-earth flex flex-col items-center gap-4 max-w-md mx-auto">
         <h2 className="text-3xl font-display">Keep Austin Connected</h2>
         <p>From backyard shows to local art fairs, we&apos;re the hub for everything happening on the East Side.</p>
         <p>Sign up for our weekly newsletter and never miss a beat.</p>

--- a/src/api.js
+++ b/src/api.js
@@ -1,11 +1,28 @@
 import events from './events.js';
 
 export async function fetchEvents() {
-  // In a real app, fetch from Ticketmaster when an API key is set.
   const apiKey = process.env.TICKETMASTER_API_KEY;
   if (apiKey) {
-    // This example just demonstrates reading the key; replace with real fetch.
-    console.log('Using Ticketmaster API key');
+    try {
+      const url = `https://app.ticketmaster.com/discovery/v2/events.json?apikey=${apiKey}&city=Austin&size=20`;
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        const eventsData = data._embedded?.events || [];
+        return eventsData.map(ev => ({
+          id: ev.id,
+          title: ev.name,
+          category: ev.classifications?.[0]?.segment?.name || 'Other',
+          role: 'guest',
+          tags: [
+            (ev.classifications?.[0]?.segment?.name || 'other').toLowerCase(),
+            'guest'
+          ]
+        }));
+      }
+    } catch (err) {
+      console.error('Ticketmaster API failed', err);
+    }
   }
   return events.map(e => ({
     ...e,


### PR DESCRIPTION
## Summary
- add viewport meta tag for proper scaling
- tune index & events pages for responsive layout
- connect `fetchEvents` to Ticketmaster when API key is present
- document mobile-first approach and Ticketmaster usage
- mark plan progress for Vercel deployment and new enhancements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844f5fcf92c8321b127279d5b75b900