### PR TITLE
Improve event discovery UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Simple demo web app listing events in Austin.
 
-The UI is built mobile first with responsive Tailwind classes so it looks great on small screens.
+The UI is built mobile first with responsive Tailwind classes so it looks great on small screens.  A shared Hero component displays the skyline on both the home and events pages.
+
+## Features
+
+- Search and filter events by category using simple chip-style buttons.
+- Event cards reveal performer images on hover and link directly to Ticketmaster for easy ticket purchase.
+- Start and end times as well as ticket prices are displayed for quick viewing.
 
 ## Setup
 

--- a/components/EventCard.js
+++ b/components/EventCard.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+function formatDate(dateStr) {
+  if (!dateStr) return '';
+  return new Date(dateStr).toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+}
+
+export default function EventCard({ event }) {
+  return (
+    <li className="relative group p-4 bg-white rounded shadow overflow-hidden">
+      {event.image && (
+        <img
+          src={event.image}
+          alt=""
+          className="absolute inset-0 w-full h-full object-cover opacity-0 group-hover:opacity-40 transition-opacity"
+        />
+      )}
+      <div className="relative space-y-1">
+        <h3 className="text-lg font-semibold">
+          <a
+            href={event.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-hotpink underline"
+          >
+            {event.title}
+          </a>
+        </h3>
+        <p className="text-sm">{event.category}</p>
+        <p className="text-sm">
+          {formatDate(event.start)}
+          {event.end ? ` - ${formatDate(event.end)}` : ''}
+        </p>
+        {event.price && <p className="text-sm">${event.price}</p>}
+      </div>
+    </li>
+  );
+}

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function Hero({ title = 'Austin Vibes', children }) {
+  return (
+    <section className="text-center">
+      <h1 className="sr-only">{title}</h1>
+      <img src="/austin-skyline.svg" alt={`${title} skyline`} className="w-full h-auto" />
+      {children && <div className="py-8">{children}</div>}
+    </section>
+  );
+}

--- a/pages/events.js
+++ b/pages/events.js
@@ -1,58 +1,65 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import Hero from '../components/Hero';
+import EventCard from '../components/EventCard';
 
-function Filter({ label, value, options, onChange }) {
+function FilterChips({ options, value, onChange }) {
   return (
-    <label className="mr-2">
-      {label}
-      <select className="ml-1 border p-1" value={value} onChange={e => onChange(e.target.value)}>
-        <option value="">All</option>
-        {options.map(opt => (
-          <option key={opt} value={opt}>{opt}</option>
-        ))}
-      </select>
-    </label>
+    <div className="flex flex-wrap gap-2">
+      <button
+        onClick={() => onChange('')}
+        className={`px-3 py-1 rounded ${value === '' ? 'bg-hotpink text-white' : 'bg-white border'}`}
+      >
+        All
+      </button>
+      {options.map(opt => (
+        <button
+          key={opt}
+          onClick={() => onChange(opt)}
+          className={`px-3 py-1 rounded ${value === opt ? 'bg-hotpink text-white' : 'bg-white border'}`}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
   );
 }
 
 export default function Events() {
   const [events, setEvents] = useState([]);
   const [category, setCategory] = useState('');
-  const [role, setRole] = useState('');
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     fetch('/api/events').then(res => res.json()).then(setEvents);
   }, []);
 
   const filtered = events.filter(e => {
-    return (!category || e.category === category) && (!role || e.role === role);
+    const matchesCategory = !category || e.category === category;
+    const matchesQuery = !query || e.title.toLowerCase().includes(query.toLowerCase());
+    return matchesCategory && matchesQuery;
   });
 
-  const recommended = filtered.slice(0, 1);
-
   const categories = Array.from(new Set(events.map(e => e.category)));
-  const roles = Array.from(new Set(events.map(e => e.role)));
 
   return (
     <>
-      <section className="min-h-screen bg-[url('/austin-skyline.svg')] bg-cover bg-center flex items-center justify-center p-8">
-        <h1 className="text-3xl sm:text-5xl font-display text-limestone drop-shadow-lg">Austin Events</h1>
-      </section>
+      <Hero title="Austin Events" />
       <main className="p-8 bg-limestone text-earth max-w-4xl mx-auto">
         <Link href="/" className="text-hotpink underline mb-4 inline-block">Back Home</Link>
-        <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-center gap-2">
-          <Filter label="Category" value={category} options={categories} onChange={setCategory} />
-          <Filter label="Role" value={role} options={roles} onChange={setRole} />
+        <div className="mb-4 flex flex-col gap-4">
+          <input
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search events"
+            className="border p-2"
+          />
+          <FilterChips options={categories} value={category} onChange={setCategory} />
         </div>
         <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
           {filtered.map(e => (
-            <li key={e.id} className="p-4 bg-white rounded shadow">{e.title} - {e.category}</li>
-          ))}
-        </ul>
-        <h2 className="text-2xl font-display text-hotpink mb-2">Recommended</h2>
-        <ul>
-          {recommended.map(e => (
-            <li key={e.id}>{e.title}</li>
+            <EventCard key={e.id} event={e} />
           ))}
         </ul>
       </main>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,15 +1,12 @@
 import Link from 'next/link';
+import Hero from '../components/Hero';
 
 export default function Home() {
   return (
     <>
-      <section className="text-center">
-        <h1 className="sr-only">Austin Vibes</h1>
-        <img src="/austin-skyline.svg" alt="Austin skyline with Austin Vibes text" className="w-full h-auto" />
-        <div className="py-8">
-          <Link href="/events" className="bg-hotpink text-limestone px-6 py-3 rounded shadow-md hover:bg-turquoise transition-colors">Browse Events</Link>
-        </div>
-      </section>
+      <Hero>
+        <Link href="/events" className="bg-hotpink text-limestone px-6 py-3 rounded shadow-md hover:bg-turquoise transition-colors">Browse Events</Link>
+      </Hero>
       <section className="p-8 bg-limestone text-earth flex flex-col items-center gap-4 max-w-md mx-auto">
         <h2 className="text-3xl font-display">Keep Austin Connected</h2>
         <p>From backyard shows to local art fairs, we&apos;re the hub for everything happening on the East Side.</p>

--- a/src/api.js
+++ b/src/api.js
@@ -13,6 +13,11 @@ export async function fetchEvents() {
           id: ev.id,
           title: ev.name,
           category: ev.classifications?.[0]?.segment?.name || 'Other',
+          url: ev.url,
+          image: ev.images?.[0]?.url,
+          start: ev.dates?.start?.dateTime,
+          end: ev.dates?.end?.dateTime,
+          price: ev.priceRanges?.[0]?.min,
           role: 'guest',
           tags: [
             (ev.classifications?.[0]?.segment?.name || 'other').toLowerCase(),

--- a/src/events.js
+++ b/src/events.js
@@ -3,18 +3,33 @@ const events = [
     id: 1,
     title: 'Live Music Night',
     category: 'Music',
+    url: 'https://ticketmaster.com/event/1',
+    image: 'https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=600&q=80',
+    start: '2025-07-01T20:00:00',
+    end: '2025-07-01T23:00:00',
+    price: 20,
     role: 'user'
   },
   {
     id: 2,
     title: 'Food Truck Festival',
     category: 'Food',
+    url: 'https://ticketmaster.com/event/2',
+    image: 'https://images.unsplash.com/photo-1532635016-bdecb0d88475?auto=format&fit=crop&w=600&q=80',
+    start: '2025-07-05T12:00:00',
+    end: '2025-07-05T18:00:00',
+    price: 10,
     role: 'guest'
   },
   {
     id: 3,
     title: 'Charity Marathon',
     category: 'Sports',
+    url: 'https://ticketmaster.com/event/3',
+    image: 'https://images.unsplash.com/photo-1520779186725-4a38b51c9a02?auto=format&fit=crop&w=600&q=80',
+    start: '2025-07-10T08:00:00',
+    end: '2025-07-10T12:00:00',
+    price: 30,
     role: 'user'
   }
 ];


### PR DESCRIPTION
## Summary
- refactor homepage and events page to share a Hero component
- add event cards that display time, price and link to Ticketmaster
- support searching and chip-style category filters
- show performer images on hover
- expand sample events and API mapping
- document new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844fde9242c832196ed6ddf8e797f5e