### PR TITLE
Make table rows clickable and normalize styles

### DIFF
--- a/components/EventRow.js
+++ b/components/EventRow.js
@@ -1,9 +1,10 @@
-import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 const fmtD = d => (d ? new Date(d).toLocaleDateString('en-US', { dateStyle: 'medium' }) : '');
 const fmtT = d => (d ? new Date(d).toLocaleTimeString('en-US', { timeStyle: 'short' }) : '');
 
 export default function EventRow({ event }) {
+  const router = useRouter();
   const style = event.image
     ? {
         backgroundImage: `url(${event.image})`,
@@ -14,13 +15,14 @@ export default function EventRow({ event }) {
       }
     : undefined;
   return (
-    <tr style={style} className="bg-cover bg-center text-limestone hover:bg-opacity-75">
-      <td className="p-2 font-semibold underline text-hotpink">
-        <Link href={`/events/${event.id}`}>{event.title}</Link>
-      </td>
+    <tr
+      onClick={() => router.push(`/events/${event.id}`)}
+      style={style}
+      className="bg-cover bg-center text-limestone hover:bg-opacity-75 cursor-pointer"
+    >
+      <td className="p-2 font-semibold">{event.title}</td>
       <td className="p-2">{fmtD(event.start)}</td>
       <td className="p-2">{fmtT(event.start)}</td>
-      <td className="p-2">{event.averageCost ? `$${event.averageCost}` : 'N/A'}</td>
     </tr>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "autoprefixer": "^10.4.21",
         "next": "^15.3.3",
+        "normalize.css": "^8.0.1",
         "postcss": "^8.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -4847,6 +4848,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
   "dependencies": {
     "autoprefixer": "^10.4.21",
     "next": "^15.3.3",
+    "normalize.css": "^8.0.1",
     "postcss": "^8.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.8"
   },
-    "devDependencies": {
-      "@tailwindcss/postcss": "^4.1.8",
-      "eslint": "^8.56.0",
-      "eslint-plugin-node": "^11.1.0",
-      "eslint-config-next": "^15.3.3"
-    }
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.8",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^15.3.3",
+    "eslint-plugin-node": "^11.1.0"
   }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import 'normalize.css';
 import '../styles/globals.css';
 export default function App({ Component, pageProps }) {
   return <Component {...pageProps} />;

--- a/pages/events.js
+++ b/pages/events.js
@@ -88,7 +88,6 @@ export default function Events() {
                   <th className="p-2">Title</th>
                   <th className="p-2">Date</th>
                   <th className="p-2">Time</th>
-                  <th className="p-2">Avg Ticket Cost</th>
                 </tr>
               </thead>
               <tbody>

--- a/pages/events/[id].js
+++ b/pages/events/[id].js
@@ -36,7 +36,6 @@ export default function EventDetail() {
       )}
       <p>Date: {formatDate(event.start)}</p>
       <p>Time: {formatTime(event.start)}</p>
-      {event.averageCost && <p>Avg. Ticket Cost: ${event.averageCost}</p>}
       <p>
         <a href={event.url} target="_blank" rel="noopener noreferrer" className="text-hotpink underline">
           Buy Tickets


### PR DESCRIPTION
## Summary
- add `normalize.css` for consistent layout
- make entire event row clickable instead of linking title
- drop price column from event lists and details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684502f6ba348321a980dd74e06ef248