### PR TITLE
Filter unsold events

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,12 @@
-import Link from 'next/link';
-import Hero from '../components/Hero';
+export async function getServerSideProps() {
+  return {
+    redirect: {
+      destination: '/events',
+      permanent: false
+    }
+  };
+}
 
 export default function Home() {
-  return (
-    <>
-      <Hero>
-        <Link href="/events" className="bg-hotpink text-limestone px-6 py-3 rounded shadow-md hover:bg-turquoise transition-colors">Browse Events</Link>
-      </Hero>
-    </>
-  );
+  return null;
 }

--- a/src/api.js
+++ b/src/api.js
@@ -8,7 +8,14 @@ export async function fetchEvents() {
       const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
-        const eventsData = data._embedded?.events || [];
+        const now = new Date();
+        const eventsData = (data._embedded?.events || []).filter(ev => {
+          const saleStart = ev.sales?.public?.startDateTime;
+          const status = ev.dates?.status?.code;
+          if (status && status !== 'onsale') return false;
+          if (saleStart && new Date(saleStart) > now) return false;
+          return true;
+        });
         return eventsData.map(ev => {
           const price = ev.priceRanges?.[0];
           const avg =


### PR DESCRIPTION
## Summary
- redirect the home page to the events listing
- skip Ticketmaster events that haven't gone on sale yet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845071109f883218d55a7634735f1c9